### PR TITLE
Add enum to control deployment types.

### DIFF
--- a/src/CdkEcsFargateBlueGreen.Infra/Program.cs
+++ b/src/CdkEcsFargateBlueGreen.Infra/Program.cs
@@ -60,12 +60,12 @@ namespace CdkEcsFargateBlueGreen.Infra
                         Account = awsAccountId,
                         Region = region
                     },
-                    EnableCodeDeployBlueGreenHook = true,
+                    DeploymentType = DeploymentType.BlueGreen,
                     VpcId = vpcId,
                     SecurityGroupId = securityGroupId,
                     LoadBalancerArn = loadBalancerArn,
                     ClusterArn = clusterArn,
-                    ClusterName = clusterName
+                    ClusterName = clusterName,
                 });
             }
 


### PR DESCRIPTION
Occasionally it is not possible to deploy the stack in a blue/green fashion. 
Add enum to control the deployment type 
- RollingUpdateSafe,
- RollingUpdateUnsafe
- BlueGreen

Output CDK warning when attempting to deploy the stack in a state that could potentially cause a service outage.